### PR TITLE
feat: Add pagination support to /api/all route

### DIFF
--- a/notify/notify_settings.py
+++ b/notify/notify_settings.py
@@ -54,3 +54,6 @@ DELETE_NF_CLASS_SELECTOR = getattr(settings, 'NOTIFY_DELETE_NF_CLASS_SELECTOR',
 
 # Time interval between ajax calls for notification update.
 UPDATE_TIME_INTERVAL = getattr(settings, 'NOTIFY_UPDATE_TIME_INTERVAL', 5000)
+
+# Page size for pagination
+PAGE_SIZE = getattr(settings, 'NOTIFY_PAGE_SIZE', 20)


### PR DESCRIPTION
NOTIFY_PAGE_SIZE variable determines the page size. Pass a ?page=<int> query string param to use

Results changed to return a pageInfo key with pagination info, and a data key with the data.